### PR TITLE
Fix: Proper handling of ARGOCD_EXTRA_ARGS in login command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,7 @@ if [ -z "${ARGOCD_ADMIN_USERNAME}" ];then
   export ARGOCD_ADMIN_USERNAME="admin"
 fi
 
-argocd login "${ARGOCD_SERVER}" --username ${ARGOCD_ADMIN_USERNAME} --password "${ARGOCD_ADMIN_PASSWORD}" "${ARGOCD_EXTRA_ARGS:-''}" || {
+argocd login "${ARGOCD_SERVER}" --username ${ARGOCD_ADMIN_USERNAME} --password "${ARGOCD_ADMIN_PASSWORD}" "${ARGOCD_EXTRA_ARGS:-}" || {
     echo "ERROR: ArgoCD login failed. Make sure to use admin account password!"
     exit 1
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,7 @@ if [ -z "${ARGOCD_ADMIN_USERNAME}" ];then
   export ARGOCD_ADMIN_USERNAME="admin"
 fi
 
-argocd login "${ARGOCD_SERVER}" --username ${ARGOCD_ADMIN_USERNAME} --password "${ARGOCD_ADMIN_PASSWORD}" "${ARGOCD_EXTRA_ARGS:-}" || {
+argocd login "${ARGOCD_SERVER}" --username ${ARGOCD_ADMIN_USERNAME} --password "${ARGOCD_ADMIN_PASSWORD}" ${ARGOCD_EXTRA_ARGS:-} || {
     echo "ERROR: ArgoCD login failed. Make sure to use admin account password!"
     exit 1
 }


### PR DESCRIPTION
This PR fixes an issue where `ARGOCD_EXTRA_ARGS` was not handled correctly in the `argocd login` command.
