### PR TITLE
Install ca-certificates in Dockerfile to fix TLS validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Instead of just creating the user
 RUN apt-get update -y \
  && apt-get upgrade -y \
- && apt-get install --no-install-recommends -y curl tar unzip \
+ && apt-get install --no-install-recommends -y curl tar unzip ca-certificates \
  && apt-get autoremove \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
This PR adds the `ca-certificates` package to the Dockerfile used for the `argocd-backup-s3` image.

### Problem
Without this package, HTTPS connections (e.g. to ArgoCD server or MinIO/S3 endpoints) fail with:

```
x509: certificate signed by unknown authority
```

### Fix
Add the following to the Dockerfile during apt installation:

```Dockerfile
apt-get install --no-install-recommends -y curl tar unzip ca-certificates
```

This installs the system trust store and allows `argocd` CLI and `aws` CLI to verify TLS certificates correctly.